### PR TITLE
prototype fix to delay federation until media is uploaded

### DIFF
--- a/app/Jobs/StatusPipeline/NewStatusPipeline.php
+++ b/app/Jobs/StatusPipeline/NewStatusPipeline.php
@@ -11,6 +11,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Redis;
 
+use Log;
+
 class NewStatusPipeline implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
@@ -44,6 +46,8 @@ class NewStatusPipeline implements ShouldQueue
      */
     public function handle()
     {
+        Log::info("aoeu: NewStatusPipeline handle");
+        Log::info(json_encode($this->status->toActivityPubObject())); 
         StatusEntityLexer::dispatch($this->status);
     }
 }

--- a/database/migrations/2023_04_11_140351_fix_federate_remote_media.php
+++ b/database/migrations/2023_04_11_140351_fix_federate_remote_media.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('statuses', function(Blueprint $table) {
+            $table->boolean('publish_delayed')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('statuses', function(Blueprint $table) {
+            $table->dropColumn('publish_delayed');
+        });
+    }
+};


### PR DESCRIPTION
I'll change the exact SQL to be more robust for a real fix, but the basic idea is:

1) When submitting a new status, check all the media for the post. If any of the media isn't finished processing (detected by lack of a cdn_url), then set a new publish_delayed flag on the status, and skip the NewStatusPipeline.

Later, when the media processing pipeline runs, check if it's the last media to be processed, and if publish_delayed was set. If so, now run the NewStatusPipeline